### PR TITLE
代码生成器与权限生成功能修复

### DIFF
--- a/src/Controllers/AdminPermissionController.php
+++ b/src/Controllers/AdminPermissionController.php
@@ -151,7 +151,7 @@ class AdminPermissionController extends AdminController
     public function autoGenerate()
     {
         $menus = Admin::adminMenuModel()::query()->get()->toArray();
-
+        $old_permissions = Admin::adminPermissionModel()::query()->get(['id', 'slug'])->keyBy('id')->toArray();
         $permissions = [];
         foreach ($menus as $menu) {
             $_httpPath =
@@ -160,16 +160,14 @@ class AdminPermissionController extends AdminController
             $menuTitle = $menu['title'];
 
             // 避免名称重复
-            foreach ($permissions as $_item){
-                if(data_get($_item, 'name') == $menuTitle){
-                    $menuTitle = sprintf('%s(%s)', $menuTitle, $menu['id']);
-                }
+            if (in_array($menuTitle, data_get($permissions, '*.name', []))) {
+                $menuTitle = sprintf('%s(%s)', $menuTitle, $menu['id']);
             }
 
             $permissions[] = [
                 'id'         => $menu['id'],
                 'name'       => $menuTitle,
-                'slug'       => (string)Str::uuid(),
+                'slug'       => data_get($old_permissions, $menu['id'] . '.slug') ?: (string)Str::uuid(),
                 'http_path'  => json_encode($_httpPath ? [$_httpPath] : ''),
                 'order'      => $menu['order'],
                 'parent_id'  => $menu['parent_id'],

--- a/src/Controllers/AdminPermissionController.php
+++ b/src/Controllers/AdminPermissionController.php
@@ -151,7 +151,7 @@ class AdminPermissionController extends AdminController
     public function autoGenerate()
     {
         $menus = Admin::adminMenuModel()::query()->get()->toArray();
-        $old_permissions = Admin::adminPermissionModel()::query()->get(['id', 'slug'])->keyBy('id')->toArray();
+        $slugMap = Admin::adminPermissionModel()::query()->get(['id', 'slug'])->keyBy('id')->toArray();
         $permissions = [];
         foreach ($menus as $menu) {
             $_httpPath =
@@ -167,7 +167,7 @@ class AdminPermissionController extends AdminController
             $permissions[] = [
                 'id'         => $menu['id'],
                 'name'       => $menuTitle,
-                'slug'       => data_get($old_permissions, $menu['id'] . '.slug') ?: (string)Str::uuid(),
+                'slug'       => data_get($slugMap, $menu['id'] . '.slug') ?: (string)Str::uuid(),
                 'http_path'  => json_encode($_httpPath ? [$_httpPath] : ''),
                 'order'      => $menu['order'],
                 'parent_id'  => $menu['parent_id'],

--- a/src/Controllers/DevTools/CodeGeneratorController.php
+++ b/src/Controllers/DevTools/CodeGeneratorController.php
@@ -530,7 +530,7 @@ class CodeGeneratorController extends AdminController
             }
 
             // Migration
-            $migrate_path = '';
+            $migratePath = '';
             if ($needs->contains('need_database_migration')) {
                 $path = MigrationGenerator::make()
                     ->title($record->title)
@@ -540,7 +540,7 @@ class CodeGeneratorController extends AdminController
                     ->generate($record->table_name, $columns);
 
                 $message .= $successMessage('Migration', $path);
-                $migrate_path = str_replace(base_path(), '', $path);
+                $migratePath = str_replace(base_path(), '', $path);
                 $paths[] = $path;
             }
 
@@ -575,8 +575,8 @@ class CodeGeneratorController extends AdminController
 
             // 创建数据库表
             if ($needs->contains('need_create_table')) {
-                if($migrate_path){
-                    Artisan::call('migrate', ['--path' => $migrate_path]);
+                if($migratePath){
+                    Artisan::call('migrate', ['--path' => $migratePath]);
                 }else{
                     Artisan::call('migrate');
                 }

--- a/src/Controllers/DevTools/CodeGeneratorController.php
+++ b/src/Controllers/DevTools/CodeGeneratorController.php
@@ -530,6 +530,7 @@ class CodeGeneratorController extends AdminController
             }
 
             // Migration
+            $migrate_path = '';
             if ($needs->contains('need_database_migration')) {
                 $path = MigrationGenerator::make()
                     ->title($record->title)
@@ -539,7 +540,7 @@ class CodeGeneratorController extends AdminController
                     ->generate($record->table_name, $columns);
 
                 $message .= $successMessage('Migration', $path);
-
+                $migrate_path = str_replace(base_path(), '', $path);
                 $paths[] = $path;
             }
 
@@ -574,7 +575,11 @@ class CodeGeneratorController extends AdminController
 
             // 创建数据库表
             if ($needs->contains('need_create_table')) {
-                Artisan::call('migrate');
+                if($migrate_path){
+                    Artisan::call('migrate', ['--path' => $migrate_path]);
+                }else{
+                    Artisan::call('migrate');
+                }
                 $message .= Artisan::output();
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
fix: 1. 代码生成器未指定迁移文件路径+部分表手动创建情况下出现表已存在的问题
      2. 每次新增功能后重新生成权限slug会被覆盖， 那么组件的permisson值需要手动跟着改变。=>生成过的权限slug将不会改变