### PR TITLE
权限管理重构

### DIFF
--- a/src/Controllers/AdminPermissionController.php
+++ b/src/Controllers/AdminPermissionController.php
@@ -20,88 +20,95 @@ class AdminPermissionController extends AdminController
 
     public function list(): Page
     {
-        $autoBtn = '';
-        if (Admin::config('admin.show_auto_generate_permission_button')) {
-            $autoBtn = amisMake()->AjaxAction()
-                ->label(__('admin.admin_permission.auto_generate'))
-                ->level('success')
-                ->confirmText(__('admin.admin_permission.auto_generate_confirm'))
-                ->api(admin_url('system/_admin_permissions_auto_generate'));
-        }
-
         $crud = $this->baseCRUD()
             ->loadDataOnce()
             ->filterTogglable(false)
             ->footerToolbar([])
             ->headerToolbar([
-                $this->createButton(true, 'lg'),
+                $this->createButton(true)->dialog(
+                    amisMake()->Dialog()->title(__('admin.create'))->body($this->createForm())->size('lg')
+                ),
                 'bulkActions',
-                $autoBtn,
                 amis('reload')->align('right'),
                 amis('filter-toggler')->align('right'),
             ])
+            ->itemCheckableOn('this.id')
+            ->expandConfig([
+                'expandAll' => true,
+                'expand'    => 'first',
+                'accordion' => false,
+            ])
             ->columns([
-                amisMake()->TableColumn('id', 'ID')->sortable(),
-                amisMake()->TableColumn('name', __('admin.admin_permission.name')),
-                amisMake()->TableColumn('slug', __('admin.admin_permission.slug')),
-                amisMake()->TableColumn('http_method', __('admin.admin_permission.http_method'))
-                    ->type('each')
-                    ->items(
-                        Tag::make()->label('${item}')->className('my-1')
-                    )
-                    ->placeholder(Tag::make()->label('ANY')),
+                amisMake()->TableColumn('name', __('admin.admin_permission.name'))->width(160),
+                amisMake()->TableColumn('slug', __('admin.admin_permission.slug'))->width(260),
+                
                 amisMake()->TableColumn('http_path', __('admin.admin_permission.http_path'))
                     ->type('each')
                     ->items(
-                        Tag::make()->label('${item}')->className('my-1')
+                        Tag::make()->label('${item}')->className('max-w-xs my-1')
                     ),
                 $this->rowActions([
-                    $this->rowEditButton(true, 'lg'),
-                    $this->rowDeleteButton(),
-                ]),
+                    $this->rowEditButton(true, 'lg')->visibleOn('${id!=0}'),
+                    $this->rowDeleteButton()->visibleOn('${id!=0}'),
+                ])->width(180),
             ]);
 
         return $this->baseList($crud);
+    }
+
+    public function createForm(): Form
+    {
+        return $this->baseForm()
+            ->api($this->getStorePath())
+            ->onEvent([])
+            ->body([
+                amisMake()->TreeSelectControl('menu', __('admin.menus'))
+                    ->searchable()
+                    ->showIcon(false)
+                    ->options(AdminMenuService::make()->getTree())
+                    ->labelField('title')
+                    ->valueField('id')
+                    ->autoCheckChildren(false)
+                    ->required()
+                    ->joinValues(false),
+
+                amisMake()->CheckboxesControl('base_permission', '基础权限')
+                    ->options(Admin::adminPermissionModel()::$base_permission)
+                    ->joinValues(false)
+                    ->extractValue(),
+
+                amisMake()->TableControl('extra_permission', '额外权限')->addable()->removable()->copyable()
+                    ->needConfirm(false)
+                    ->columns([
+                        amisMake()->TextControl('name', __('admin.admin_permission.name'))->required(),
+
+                        amisMake()->TagControl('http_path', __('admin.admin_permission.http_path'))
+                            ->extractValue()
+                            ->joinValues(false)
+                            ->placeholder('eg: post:/system/admin (请求方式:路径, 多条记录以逗号分割)'),
+
+                    ])
+            ]);
     }
 
     public function form(): Form
     {
         return $this->baseForm()->body([
             amisMake()->TextControl('name', __('admin.admin_permission.name'))->required(),
-            amisMake()->TextControl('slug', __('admin.admin_permission.slug'))->required(),
-            amisMake()->TreeSelectControl('parent_id', __('admin.parent'))
-                ->labelField('name')
-                ->valueField('id')
-                ->value(0)
-                ->options($this->service->getTree()),
-            amisMake()->CheckboxesControl('http_method', __('admin.admin_permission.http_method'))
-                ->options($this->getHttpMethods())
-                ->description(__('admin.admin_permission.http_method_description'))
-                ->joinValues(false)
-                ->extractValue(),
-            amisMake()->NumberControl('order', __('admin.order'))
-                ->required()
-                ->labelRemark(__('admin.order_asc'))
-                ->displayMode('enhance')
-                ->min(0)
-                ->value(0),
-            amisMake()->SelectControl('http_path', __('admin.admin_permission.http_path'))
+            amisMake()->TextControl('slug', __('admin.admin_permission.slug'))->readOnly(),
+
+            amisMake()->TagControl('http_path', __('admin.admin_permission.http_path'))
+                ->extractValue()
+                ->joinValues(false),
+            amisMake()->TreeSelectControl('menu_id', __('admin.menus'))
                 ->searchable()
-                ->multiple()
-                ->options($this->getRoutes())
-                ->autoCheckChildren(false)
-                ->joinValues(false)
-                ->extractValue(),
-            amisMake()->TreeSelectControl('menus', __('admin.menus'))
-                ->searchable()
-                ->multiple()
                 ->showIcon(false)
                 ->options(AdminMenuService::make()->getTree())
                 ->labelField('title')
                 ->valueField('id')
                 ->autoCheckChildren(false)
-                ->joinValues(false)
-                ->extractValue(),
+                ->joinValues(true),
+
         ]);
     }
 
@@ -112,111 +119,9 @@ class AdminPermissionController extends AdminController
 
     private function getHttpMethods(): array
     {
-        return collect(Admin::adminPermissionModel()::$httpMethods)->map(fn($method) => [
+        return collect(Admin::adminPermissionModel()::$httpMethods)->map(fn ($method) => [
             'value' => $method,
             'label' => $method,
         ])->toArray();
-    }
-
-    public function getRoutes(): array
-    {
-        $prefix = (string)Admin::config('admin.route.prefix');
-
-        $container = collect();
-        return collect(app('router')->getRoutes())->map(function ($route) use ($prefix, $container) {
-            if (!Str::startsWith($uri = $route->uri(), $prefix) && $prefix && $prefix !== '/') {
-                return null;
-            }
-            if (!Str::contains($uri, '{')) {
-                if ($prefix !== '/') {
-                    $route = Str::replaceFirst($prefix, '', $uri . '*');
-                } else {
-                    $route = $uri . '*';
-                }
-
-                $route !== '*' && $container->push($route);
-            }
-            $path = preg_replace('/{.*}+/', '*', $uri);
-            $prefix !== '/' && $path = Str::replaceFirst($prefix, '', $path);
-
-            return $path;
-        })->merge($container)->filter()->unique()->map(function ($method) {
-            return [
-                'value' => $method,
-                'label' => $method,
-            ];
-        })->values()->all();
-    }
-
-    public function autoGenerate()
-    {
-        $menus = Admin::adminMenuModel()::query()->get()->toArray();
-        $slugMap = Admin::adminPermissionModel()::query()->get(['id', 'slug'])->keyBy('id')->toArray();
-        $permissions = [];
-        foreach ($menus as $menu) {
-            $_httpPath =
-                $menu['url_type'] == Admin::adminMenuModel()::TYPE_ROUTE ? $this->getHttpPath($menu['url']) : '';
-
-            $menuTitle = $menu['title'];
-
-            // 避免名称重复
-            if (in_array($menuTitle, data_get($permissions, '*.name', []))) {
-                $menuTitle = sprintf('%s(%s)', $menuTitle, $menu['id']);
-            }
-
-            $permissions[] = [
-                'id'         => $menu['id'],
-                'name'       => $menuTitle,
-                'slug'       => data_get($slugMap, $menu['id'] . '.slug') ?: (string)Str::uuid(),
-                'http_path'  => json_encode($_httpPath ? [$_httpPath] : ''),
-                'order'      => $menu['order'],
-                'parent_id'  => $menu['parent_id'],
-                'created_at' => $menu['created_at'],
-                'updated_at' => $menu['updated_at'],
-            ];
-        }
-
-        Admin::adminPermissionModel()::query()->truncate();
-        Admin::adminPermissionModel()::query()->insert($permissions);
-
-        $permissionClass = Admin::adminPermissionModel();
-        $pivotTable      = (new $permissionClass)->menus()->getTable();
-
-        DB::table($pivotTable)->truncate();
-        foreach ($permissions as $item) {
-            $query = DB::table($pivotTable);
-            $query->insert([
-                'permission_id' => $item['id'],
-                'menu_id'       => $item['id'],
-            ]);
-
-            $_id = $item['id'];
-            while ($item['parent_id'] != 0) {
-                (clone $query)->insert([
-                    'permission_id' => $_id,
-                    'menu_id'       => $item['parent_id'],
-                ]);
-
-                $item = Admin::adminMenuModel()::query()->find($item['parent_id']);
-            }
-        }
-
-        return $this->response()->successMessage(
-            __('admin.successfully_message', ['attribute' => __('admin.admin_permission.auto_generate')])
-        );
-    }
-
-    private function getHttpPath($uri)
-    {
-        $excepts = ['/', '', '-'];
-        if (in_array($uri, $excepts)) {
-            return '';
-        }
-
-        if (!str_starts_with($uri, '/')) {
-            $uri = '/' . $uri;
-        }
-
-        return $uri . '*';
     }
 }

--- a/src/Controllers/AdminRoleController.php
+++ b/src/Controllers/AdminRoleController.php
@@ -4,6 +4,7 @@ namespace Slowlyo\OwlAdmin\Controllers;
 
 use Slowlyo\OwlAdmin\Renderers\Page;
 use Slowlyo\OwlAdmin\Renderers\Form;
+use Slowlyo\OwlAdmin\Services\AdminMenuService;
 use Slowlyo\OwlAdmin\Services\AdminRoleService;
 use Slowlyo\OwlAdmin\Services\AdminPermissionService;
 
@@ -37,8 +38,8 @@ class AdminRoleController extends AdminController
                     ->type('datetime')
                     ->sortable(true),
                 amisMake()->Operation()->label(__('admin.actions'))->buttons([
-                    $this->setPermission(),
-                    $this->rowEditButton(true),
+                    $this->setPermission()->visibleOn('${slug != "administrator"}'),
+                    $this->rowEditButton(true)->visibleOn('${slug != "administrator"}'),
                     $this->rowDeleteButton()->visibleOn('${slug != "administrator"}'),
                 ]),
             ]);
@@ -56,32 +57,34 @@ class AdminRoleController extends AdminController
 
     protected function setPermission()
     {
-        return amisMake()->DrawerAction()->label(__('admin.admin_role.set_permissions'))->icon('fa-solid fa-gear')->level('link')->drawer(
-            amisMake()->Drawer()->title(__('admin.admin_role.set_permissions'))->resizable()->closeOnOutside()->closeOnEsc()->body([
-                amisMake()
-                    ->Form()
-                    ->api(admin_url('system/admin_role_save_permissions'))
-                    ->initApi($this->getEditGetDataPath())
-                    ->mode('normal')
-                    ->data(['id' => '${id}'])
-                    ->body([
-                        amisMake()->TreeControl()
-                            ->name('permissions')
-                            ->label()
-                            ->multiple()
-                            ->options(AdminPermissionService::make()->getTree())
-                            ->searchable()
-                            ->onlyChildren()
-                            ->joinValues(false)
-                            ->extractValue()
-                            ->size('full')
-                            ->className('h-full b-none')
-                            ->inputClassName('h-full tree-full')
-                            ->labelField('name')
-                            ->valueField('id'),
-                    ]),
-            ])
-        );
+        return amisMake()->DrawerAction()->label(__('admin.admin_role.set_permissions'))
+            ->icon('fa-solid fa-lock')
+            ->level('link')->drawer(
+                amisMake()->Drawer()->title(__('admin.admin_role.set_permissions'))->resizable()->closeOnOutside()->closeOnEsc()->body([
+                    amisMake()
+                        ->Form()
+                        ->api(admin_url('system/admin_role_save_permissions'))
+                        ->initApi($this->getEditGetDataPath())
+                        ->mode('normal')
+                        ->data(['id' => '${id}'])
+                        ->body([
+                            amisMake()->TreeControl()
+                                ->name('permissions')
+                                ->label()
+                                ->multiple()
+                                ->options($this->service->getMenuPermission())
+                                ->searchable()
+                                ->autoCheckChildren(false)
+                                ->joinValues(false)
+                                ->extractValue()
+                                ->size('full')
+                                ->className('h-full b-none')
+                                ->inputClassName('h-full tree-full')
+                                ->labelField('name')
+                                ->valueField('tag'),
+                        ]),
+                ])
+            );
     }
 
     public function savePermissions()
@@ -90,6 +93,7 @@ class AdminRoleController extends AdminController
 
         return $this->autoResponse($result, __('admin.save'));
     }
+
 
     public function form(): Form
     {

--- a/src/Models/AdminMenu.php
+++ b/src/Models/AdminMenu.php
@@ -36,4 +36,9 @@ class AdminMenu extends BaseModel
             return __("menu.{$value}") == "menu.{$value}" ? $value : __("menu.{$value}");
         });
     }
+
+    public function permissions()
+    {
+        return $this->hasMany(AdminPermission::class, 'menu_id');
+    }
 }

--- a/src/Models/AdminRole.php
+++ b/src/Models/AdminRole.php
@@ -14,11 +14,18 @@ class AdminRole extends BaseModel
             ->withTimestamps();
     }
 
+    public function menus()
+    {
+        return $this->belongsToMany(AdminMenu::class, 'admin_role_menus', 'role_id', 'menu_id')
+            ->withTimestamps();
+    }
+
     protected static function boot(): void
     {
         parent::boot();
         static::deleting(function (AdminRole $model) {
             $model->permissions()->detach();
+            $model->menus()->detach();
         });
     }
 }

--- a/src/Renderers/BaseRenderer.php
+++ b/src/Renderers/BaseRenderer.php
@@ -53,7 +53,7 @@ class BaseRenderer implements \JsonSerializable
 
         if (key_exists($permissionKey, $this->amisSchema)) {
             if (!admin_user()->can($this->amisSchema[$permissionKey])) {
-                return null;
+                return '';
             }
         }
 

--- a/src/Services/AdminPermissionService.php
+++ b/src/Services/AdminPermissionService.php
@@ -6,11 +6,13 @@ use Illuminate\Support\Arr;
 use Slowlyo\OwlAdmin\Admin;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Str;
 use Slowlyo\OwlAdmin\Models\AdminPermission;
 
 /**
  * @method AdminPermission getModel()
- * @method AdminPermission|Builder query()
+ * @method AdminPermission|Builder|QueryBuilder query()
  */
 class AdminPermissionService extends AdminService
 {
@@ -23,46 +25,64 @@ class AdminPermissionService extends AdminService
 
     public function getTree(): array
     {
-        $list = $this->query()->orderBy('order')->get()->toArray();
+        $list = $this->query()->orderBy('menu_id')->with('menu:id,title,url')->get();
+        $tree = collect([]);
+        $list->groupBy('menu_id')
+            ->map(function ($item, $key) use ($tree) {
+                if ($key == 0) {
+                    $tree->push(...$item);
+                } else {
+                    $menu = $item->first()->menu;
+                    $tree->push(['id' => 0, 'name' => $menu->title, 'children' => $item, 'http_path' => [$menu->url]]);
+                }
+            });
 
-        return array2tree($list);
-    }
-
-    public function parentIsChild($id, $parent_id): bool
-    {
-        $parent = $this->query()->find($parent_id);
-
-        do {
-            if ($parent->parent_id == $id) {
-                return true;
-            }
-            // 如果没有parent 则为顶级 退出循环
-            $parent = $parent->parent;
-        } while ($parent);
-
-        return false;
-    }
-
-    public function getEditData($id): Model|\Illuminate\Database\Eloquent\Collection|Builder|array|null
-    {
-        $permission = parent::getEditData($id);
-
-        $permission->load(['menus']);
-
-        return $permission;
+        return $tree->toArray();
     }
 
     public function store($data): bool
     {
-        if ($this->hasRepeated($data)) {
-            return false;
+        $base_permission = Arr::pull($data, 'base_permission');
+        $extra_permission = Arr::pull($data, 'extra_permission');
+        $permissions = collect();
+        $menu_id = Arr::pull($data, 'menu.id');
+        $path = Arr::pull($data, 'menu.url');
+
+        if (!empty($extra_permission)) {
+            foreach ($extra_permission as $permission) {
+                $permission['slug'] = Str::uuid();
+                $permission['menu_id'] = $menu_id;
+                $permissions->push($permission);
+            }
         }
 
-        $columns = $this->getTableColumns();
+        if (!empty($base_permission)) {
+            foreach ($base_permission as $base) {
+                $permission = match ($base) {
+                    'show'      => ['name' => '详情', 'slug' => Str::uuid(), 'http_path' => ['get:' . $path], 'menu_id' => $menu_id],
+                    'create'    => ['name' => '新增', 'slug' => Str::uuid(), 'http_path' => ['post:' . $path], 'menu_id' => $menu_id],
+                    'edit'      => ['name' => '编辑', 'slug' => Str::uuid(), 'http_path' => ['get:' . $path . '/*/edit', 'put:'. $path . '/*'], 'menu_id' => $menu_id],
+                    'export'    => ['name' => '导出', 'slug' => Str::uuid(), 'http_path' => ['get:' . $path], 'menu_id' => $menu_id],
+                    'delete'    => ['name' => '删除', 'slug' => Str::uuid(), 'http_path' => ['delete:' . $path . '/*'], 'menu_id' => $menu_id],
+                    'batchDel'  => ['name' => '批量删除', 'slug' => Str::uuid(), 'http_path' => ['delete:' . $path . '/*'], 'menu_id' => $menu_id],
+                    default => null,
+                };
+                $permission && $permissions->push($permission);
+            }
+        }
 
-        $model = $this->getModel();
+        if($permissions->isNotEmpty()){
+            $permissions->push(['name' => '列表', 'slug' => Str::uuid(), 'http_path' => ['get:' . $path], 'menu_id' => $menu_id]);
+        }
 
-        return $this->saveData($data, $columns, $model);
+        $permissions = $permissions->map(function($item){
+            $item['http_path'] = json_encode($item['http_path']??[]);
+            return $item;
+        })->all();
+        
+        $this->getModel()->insert($permissions);
+
+        return true;
     }
 
     public function update($primaryKey, $data): bool
@@ -71,14 +91,9 @@ class AdminPermissionService extends AdminService
             return false;
         }
 
-        $columns = $this->getTableColumns();
+        $data['menu_id'] = $data['menu_id'] ?: 0;
 
-        $parent_id = Arr::get($data, 'parent_id');
-        if ($parent_id != 0) {
-            if ($this->parentIsChild($primaryKey, $parent_id)) {
-                return $this->setError(__('admin.admin_permissions.parent_id_not_allow'));
-            }
-        }
+        $columns = $this->getTableColumns();
 
         $model = $this->query()->whereKey($primaryKey)->first();
 
@@ -87,12 +102,12 @@ class AdminPermissionService extends AdminService
 
     public function hasRepeated($data, $id = 0): bool
     {
-        $query = $this->query()->when($id, fn($query) => $query->where('id', '<>', $id));
+        $query = $this->query()->when($id, fn ($query) => $query->where('id', '<>', $id));
 
-        if ((clone $query)->where('name', $data['name'])->exists()) {
-            $this->setError(__('admin.admin_permission.name_already_exists'));
-            return true;
-        }
+        // if ((clone $query)->where('name', $data['name'])->exists()) {
+        //     $this->setError(__('admin.admin_permission.name_already_exists'));
+        //     return true;
+        // }
 
         if ((clone $query)->where('slug', $data['slug'])->exists()) {
             $this->setError(__('admin.admin_permission.slug_already_exists'));
@@ -116,7 +131,7 @@ class AdminPermissionService extends AdminService
      */
     protected function saveData($data, array $columns, AdminPermission $model): bool
     {
-        $menus = Arr::pull($data, 'menus');
+        // $menus = Arr::pull($data, 'menus');
 
         foreach ($data as $k => $v) {
             if (!in_array($k, $columns)) {
@@ -127,7 +142,7 @@ class AdminPermissionService extends AdminService
         }
 
         if ($model->save()) {
-            $model->menus()->sync(Arr::has($menus, '0.id') ? Arr::pluck($menus, 'id') : $menus);
+            // $model->menus()->sync(Arr::has($menus, '0.id') ? Arr::pluck($menus, 'id') : $menus);
 
             return true;
         }

--- a/src/Services/AdminService.php
+++ b/src/Services/AdminService.php
@@ -2,6 +2,7 @@
 
 namespace Slowlyo\OwlAdmin\Services;
 
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
@@ -42,7 +43,7 @@ abstract class AdminService
         return $this->tableColumn;
     }
 
-    public function query(): Builder
+    public function query(): Builder|QueryBuilder
     {
         return $this->modelName::query();
     }

--- a/src/Support/Cores/Menu.php
+++ b/src/Support/Cores/Menu.php
@@ -27,10 +27,8 @@ class Menu
         if ($user->isAdministrator() || Admin::config('admin.auth.enable') === false) {
             $list = AdminMenuService::make()->query()->orderBy('order')->get();
         } else {
-            $user->load('roles.permissions.menus');
+            $user->load('roles.menus');
             $list = $user->roles
-                ->pluck('permissions')
-                ->flatten()
                 ->pluck('menus')
                 ->flatten()
                 ->unique('id')


### PR DESCRIPTION
1. 角色直接关联菜单，不再通过权限进行关联
2. 鉴权方法调整
3. 角色分配权限及菜单调整
4. 权限表内容调整