### PR TITLE
在获取数据前先过滤 null 值

### DIFF
--- a/src/Services/AdminService.php
+++ b/src/Services/AdminService.php
@@ -69,8 +69,11 @@ abstract class AdminService
     public function getEditData($id): Model|\Illuminate\Database\Eloquent\Collection|Builder|array|null
     {
         $model = $this->getModel();
+        $hidden = collect([$model->getCreatedAtColumn(), $model->getUpdatedAtColumn()])->filter(function ($item) {
+            return $item !== null;
+        })->toArray();
 
-        return $this->query()->find($id)->makeHidden([$model->getCreatedAtColumn(), $model->getUpdatedAtColumn()]);
+        return $this->query()->find($id)->makeHidden($hidden);
     }
 
     /**


### PR DESCRIPTION
但模型中的 UPDATED_AT 或者 UPDATED_AT 值为 null 的时候需要检测它们是否为 null 不然会报错。

这种将其设置为 null 的情况通常发生在需要由 laravel 仅维护其中一种字段的情况下发生。