### PR TITLE
optimize:优化代码生成器中需要用到多个数组的字段类型。

### DIFF
--- a/src/Renderers/BaseRenderer.php
+++ b/src/Renderers/BaseRenderer.php
@@ -30,13 +30,9 @@ class BaseRenderer implements \JsonSerializable
 
     public function set($name, $value)
     {
-        if(is_string($value) && is_array(json_decode($value, true)) && (json_last_error() == JSON_ERROR_NONE)){
-          $this->amisSchema[$name] = json_decode($value, true);
-        }else{
-          $this->amisSchema[$name] = $value;
-        }
+      $this->amisSchema[$name] = $value;
 
-        return $this;
+      return $this;
     }
 
     public function jsonSerialize()

--- a/src/Renderers/BaseRenderer.php
+++ b/src/Renderers/BaseRenderer.php
@@ -30,7 +30,11 @@ class BaseRenderer implements \JsonSerializable
 
     public function set($name, $value)
     {
-        $this->amisSchema[$name] = $value;
+        if(is_string($value) && is_array(json_decode($value, true)) && (json_last_error() == JSON_ERROR_NONE)){
+          $this->amisSchema[$name] = json_decode($value, true);
+        }else{
+          $this->amisSchema[$name] = $value;
+        }
 
         return $this;
     }

--- a/src/Support/CodeGenerator/ControllerGenerator.php
+++ b/src/Support/CodeGenerator/ControllerGenerator.php
@@ -278,6 +278,10 @@ class ControllerGenerator extends BaseGenerator
                 $item .= collect($property)->map(function ($item) {
                     $_val = Arr::get($item, 'value');
 
+                    if(is_string($_val) && is_array(json_decode($_val, true)) && (json_last_error() == JSON_ERROR_NONE)){
+                      return '->' . Arr::get($item, 'name') . '(' . $this->jsonToStringArray($_val) . ')';
+                    }
+
                     if (filled($_val) && !in_array($_val, ['true', 'false']) && !is_numeric($_val)) {
                         $_val = "'{$_val}'";
                     }
@@ -294,5 +298,38 @@ class ControllerGenerator extends BaseGenerator
             'form_component' => "amis()->TextControl('{$column['name']}', '{$label}')",
             'detail_component' => "amis()->TextControl('{$column['name']}', '{$label}')->static()",
         };
+    }
+
+    private function jsonToStringArray($jsonString) {
+      // 首先，检查输入是否为有效的JSON字符串
+      $dataArray = json_decode($jsonString, true);
+      if (json_last_error() !== JSON_ERROR_NONE) {
+        // 如果json_decode遇到错误，返回错误信息
+        return $jsonString;
+      }
+
+      // 遍历数组，确保所有的字符串都正确处理Unicode编码，特别是中文
+      array_walk_recursive($dataArray, function (&$item) {
+        if (is_string($item)) {
+          $item = mb_convert_encoding($item, 'UTF-8', 'UTF-8');
+        }
+      });
+
+      // 使用var_export()生成数组的字符串表示，然后将其返回
+      $phpArrayString = var_export($dataArray, true);
+
+      // 转换为短数组语法
+      $phpArrayString = preg_replace('/array \(/', '[', $phpArrayString);
+      $phpArrayString = preg_replace('/\)$/', ']', $phpArrayString);
+      $phpArrayString = str_replace(')', ']', $phpArrayString);
+
+      // 去除数字索引
+      $phpArrayString = preg_replace('/\d+ => /', '', $phpArrayString);
+
+      // 去除多余的空格和换行，使输出更为紧凑
+      $phpArrayString = preg_replace('/ =>\s+\[/', '=> [', $phpArrayString);
+      $phpArrayString = str_replace(["\r\n", "\r", "\n", "\t", "  "], '', $phpArrayString);
+
+      return $phpArrayString;
     }
 }


### PR DESCRIPTION
如：编辑/新增内的字段的RadiosControl类型中的options属性，为了方便提前能够预填字段内的选项，可以直接输入json格式的字符串，如`[{"label":"\u4fdd\u5bc6","value":0},{"label":"\u7537","value":1},{"label":"\u5973","value":2}]`，生成代码后即可立即使用。

更改代码：
文件：src/Renderers/BaseRenderer.php
函数：33
代码内容：
```
if(is_string($value) && is_array(json_decode($value, true)) && (json_last_error() == JSON_ERROR_NONE)){
 $this->amisSchema[$name] = json_decode($value, true);
}else{
 $this->amisSchema[$name] = $value;
}
```
逻辑说明：
增加针对字符串内容进行json格式判断，如果为json格式，将进行解码并赋值

演示图片：
<img width="1066" alt="image" src="https://github.com/Slowlyo/owl-admin/assets/48904825/377d7fc8-80c1-40a0-b8ed-6e3128a792c1">
