### PR TITLE
检测扩展是否需要自动安装字典

### DIFF
--- a/src/Extend/ServiceProvider.php
+++ b/src/Extend/ServiceProvider.php
@@ -370,8 +370,14 @@ abstract class ServiceProvider extends LaravelServiceProvider
     {
         if ($enable) {
             $this->refreshMenu();
+            if(method_exists($this,'refreshDict')){
+                $this->refreshDict();
+            }
         } else {
             $this->flushMenu();
+            if(method_exists($this,'flushDict')){
+                $this->flushDict();
+            }
         }
     }
 


### PR DESCRIPTION
可以在扩展的ServiceProvider内，use Slowlyo\OwlDict\Extend\CanImportDict; 然后在成员属性 定义dict变量 实现自动化安装字典。类似于menu的使用方式。