### PR TITLE
扩展菜单父级支持根据url路径对应

### DIFF
--- a/src/Extend/CanImportMenu.php
+++ b/src/Extend/CanImportMenu.php
@@ -3,6 +3,7 @@
 namespace Slowlyo\OwlAdmin\Extend;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Slowlyo\OwlAdmin\Admin;
 use Illuminate\Support\Facades\Validator;
 
@@ -95,6 +96,12 @@ trait CanImportMenu
         }
 
         $menuModel = $this->getMenuModel();
+
+        if (Str::startsWith($parent,'/')){
+            return $menuModel::query()
+                ->where('url', $parent)
+                ->value('id') ?: 0;
+        }
 
         return $menuModel::query()
             ->where('title', $parent)


### PR DESCRIPTION
扩展菜单 parent属性设置为其他菜单的url时，可将菜单添加到原有其他菜单的子级