### PR TITLE
修正动态API功能检索所有模型的时候检索到抽象类型

### DIFF
--- a/src/Services/AdminRelationshipService.php
+++ b/src/Services/AdminRelationshipService.php
@@ -83,7 +83,7 @@ class AdminRelationshipService extends AdminService
             ->keys()
             ->filter(fn($item) => str_contains($item, 'Models\\'))
             ->filter(fn($item) => @class_exists($item))
-            ->filter(fn($item) => (new \ReflectionClass($item))->isSubclassOf(Model::class))
+            ->filter(fn($item) => (new \ReflectionClass($item))->isSubclassOf(Model::class) && !(new \ReflectionClass($item))->isAbstract())
             ->merge($modelDirClass)
             ->unique()
             ->filter(fn($item) => in_array(app($item)->getTable(), $tables))


### PR DESCRIPTION
### 现象
- 冲突发现于`laravel-lang/common`的扩展包，在使用动态API的功能时候加载所有Model的时候报错，报错提示如下。
```
Illuminate\Contracts\Container\BindingResolutionException
Target [LaravelLang\Models\Eloquent\Translation] is not instantiable.
```
### 定位
- 打开该文件`vendor/laravel-lang/models/src/Eloquent/Translation.php`发现该类使用了抽象类声明。
- 在3.9.5版本中的该行`vendor/slowlyo/owl-admin/src/Services/AdminRelationshipService.php:89`实例过程中发生的报错。
``` php
$models = collect($classMap)
      ->keys()
      ->filter(fn($item) => str_contains($item, 'Models\\'))
      ->filter(fn($item) => @class_exists($item))
      ->filter(fn($item) => (new \ReflectionClass($item))->isSubclassOf(Model::class))
      ->merge($modelDirClass)
      ->unique()
      ->filter(fn($item) => in_array(app($item)->getTable(), $tables)) // 错误行
      ->values()
      ->map(fn($item) => [
          'label' => Str::of($item)->explode('\\')->pop(),
          'table' => app($item)->getTable(),
          'value' => $item,
      ]);
```
### 解决
- 筛选中加入去除抽象类的检查。
``` php
$models = collect($classMap)
            ->keys()
            ->filter(fn($item) => str_contains($item, 'Models\\'))
            ->filter(fn($item) => @class_exists($item))
            ->filter(fn($item) => (new \ReflectionClass($item))->isSubclassOf(Model::class) && !(new \ReflectionClass($item))->isAbstract()) // 修改行
            ->merge($modelDirClass)
            ->unique()
            ->filter(fn($item) => in_array(app($item)->getTable(), $tables))
            ->values()
            ->map(fn($item) => [
                'label' => Str::of($item)->explode('\\')->pop(),
                'table' => app($item)->getTable(),
                'value' => $item,
            ]);
```