### PR TITLE
fix: 动态 api 中统一模板的多个配置返回结果不变

### DIFF
--- a/src/Controllers/AdminApiController.php
+++ b/src/Controllers/AdminApiController.php
@@ -22,6 +22,6 @@ class AdminApiController extends AdminController
             return $this->response()->success();
         }
 
-        return app($api->template)->handle();
+        return app($api->template)->setApiRecord($api)->handle();
     }
 }

--- a/src/Support/Apis/AdminBaseApi.php
+++ b/src/Support/Apis/AdminBaseApi.php
@@ -40,6 +40,13 @@ abstract class AdminBaseApi implements AdminApiInterface
         return self::$apiRecord;
     }
 
+    public function setApiRecord($apiRecord)
+    {
+        self::$apiRecord = $apiRecord;
+
+        return $this;
+    }
+
     /**
      * 获取接口参数, 可以通过传入 xxx.xxx 的方式获取指定参数
      *


### PR DESCRIPTION
## 问题描述
动态 API 中，同一个模板配置多个 api 之后，返回的数据永远是该模板的第一个接口的数据。

## 问题复现
1. 配置两条模板一致但 Model 不同的数据
![图片](https://github.com/user-attachments/assets/bb4a5515-0b95-45f0-8a9a-e40becb92441)

![图片](https://github.com/user-attachments/assets/6bcf24f1-3ffa-4715-8c43-c4a245927e9a)

![图片](https://github.com/user-attachments/assets/9c33b751-4534-4d2c-9252-a86b8cf9b0c5)

2. 点击预览按钮，返回的都是 `users` 表的数据，

```bash
curl 'http://127.0.0.1:8001/admin-api/test1' \
  -H 'Accept: application/json, text/plain, */*'  

# 省略其他 Header 头
```

```json
{
    "status": 0,
    "msg": "",
    "doNotDisplayToast": 0,
    "_debug": {
        "sql": [
            "[17.05 ms] select * from `cache` where `key` in ('admin_has_table_admin_relationships')",
            "[3.01 ms] select * from `cache` where `key` in ('admin_relationships')",
            "[3.6 ms] select * from `personal_access_tokens` where `personal_access_tokens`.`id` = 1 limit 1",
            "[2.92 ms] select * from `admin_users` where `admin_users`.`id` = 1 limit 1",
            "[5.94 ms] update `personal_access_tokens` set `last_used_at` = '2024-09-27 08:56:32', `personal_access_tokens`.`updated_at` = '2024-09-27 08:56:32' where `id` = 1",
            "[3.47 ms] select `admin_roles`.*, `admin_role_users`.`user_id` as `pivot_user_id`, `admin_role_users`.`role_id` as `pivot_role_id`, `admin_role_users`.`created_at` as `pivot_created_at`, `admin_role_users`.`updated_at` as `pivot_updated_at` from `admin_roles` inner join `admin_role_users` on `admin_roles`.`id` = `admin_role_users`.`role_id` where `admin_role_users`.`user_id` = 1",
            "[2.78 ms] select * from `admin_apis` where `path` = '\/test1' limit 1",
            "[2.61 ms] select * from `admin_apis` where `path` = 'test1' limit 1",
            "[5.19 ms] select * from `admin_apis` where `template` = 'Slowlyo\\OwlAdmin\\Support\\Apis\\DataListApi' limit 1",
            "[5.6 ms] select column_name as `name`, data_type as `type_name`, column_type as `type`, collation_name as `collation`, is_nullable as `nullable`, column_default as `default`, column_comment as `comment`, generation_expression as `expression`, extra as `extra` from information_schema.columns where table_schema = 'owl_admin' and table_name = 'users' order by ordinal_position asc",
            "[2.57 ms] select count(*) as aggregate from `users`"
        ]
    },
    "data": {
        "items": [],
        "total": 0
    }
}
```


```bash
curl 'http://127.0.0.1:8001/admin-api/test2' \
  -H 'Accept: application/json, text/plain, */*'  

# 省略其他 Header 头
```

```json
{
    "status": 0,
    "msg": "",
    "doNotDisplayToast": 0,
    "_debug": {
        "sql": [
            "[10.47 ms] select * from `cache` where `key` in ('admin_has_table_admin_relationships')",
            "[3.42 ms] select * from `cache` where `key` in ('admin_relationships')",
            "[5.79 ms] select * from `personal_access_tokens` where `personal_access_tokens`.`id` = 1 limit 1",
            "[3.85 ms] select * from `admin_users` where `admin_users`.`id` = 1 limit 1",
            "[6.3 ms] update `personal_access_tokens` set `last_used_at` = '2024-09-27 08:56:24', `personal_access_tokens`.`updated_at` = '2024-09-27 08:56:24' where `id` = 1",
            "[3.17 ms] select `admin_roles`.*, `admin_role_users`.`user_id` as `pivot_user_id`, `admin_role_users`.`role_id` as `pivot_role_id`, `admin_role_users`.`created_at` as `pivot_created_at`, `admin_role_users`.`updated_at` as `pivot_updated_at` from `admin_roles` inner join `admin_role_users` on `admin_roles`.`id` = `admin_role_users`.`role_id` where `admin_role_users`.`user_id` = 1",
            "[2.74 ms] select * from `admin_apis` where `path` = '\/test2' limit 1",
            "[2.48 ms] select * from `admin_apis` where `path` = 'test2' limit 1",
            "[4.11 ms] select * from `admin_apis` where `template` = 'Slowlyo\\OwlAdmin\\Support\\Apis\\DataListApi' limit 1",
            "[5.02 ms] select column_name as `name`, data_type as `type_name`, column_type as `type`, collation_name as `collation`, is_nullable as `nullable`, column_default as `default`, column_comment as `comment`, generation_expression as `expression`, extra as `extra` from information_schema.columns where table_schema = 'owl_admin' and table_name = 'users' order by ordinal_position asc",
            "[2.78 ms] select count(*) as aggregate from `users`"
        ]
    },
    "data": {
        "items": [],
        "total": 0
    }
}
```

## 问题原因
1. 模板代码中 `getApiRecord` 方法实现的是
```php
    public function getApiRecord()
    {
        if (!self::$apiRecord) {
            self::$apiRecord = AdminApiService::make()->getApiByTemplate(static::class);
        }
  
        return self::$apiRecord;
    }
```
形成了单例模式，同样的模板 apiRecord 的值都是一样的。

2. 同时， `getApiByTemplate` 的实现为：

```php
    public function getApiByTemplate($template)
    {
        return $this->query()->where('template', $template)->first();
    }
```
查询的结果也只会是模板的默认排序的第一条数据。

## 解决方案
添加 setApiRecord 方法，并且在 AdminApiController 中使用该方法设置正确的 apiRecord。


