### PR TITLE
修复registerConfig 时出现的错误

### DIFF
--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -101,7 +101,9 @@ class AdminServiceProvider extends ServiceProvider
 
     protected function registerConfig()
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/admin.php', 'admin');
+        $this->mergeConfigFrom(base_path('config/admin.php'), 'admin');
+        
+        base_path('config/admin.php')
 
         if ($moduleConfig = app(Module::class)->allConfigPath()) {
             foreach ($moduleConfig as $key => $path) {


### PR DESCRIPTION
在composer update 的时候出现 
```php
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

   ErrorException 

  require(/var/www/html/vendor/slowlyo/owl-admin/src/../config/admin.php): Failed to open stream: No such file or directory

  at vendor/laravel/framework/src/Illuminate/Support/ServiceProvider.php:138
    134▕         if (! ($this->app instanceof CachesConfiguration && $this->app->configurationIsCached())) {
    135▕             $config = $this->app->make('config');
    136▕ 
    137▕             $config->set($key, array_merge(
  ➜ 138▕                 require $path, $config->get($key, [])
    139▕             ));
    140▕         }
    141▕     }
    142▕ 

      +10 vendor frames 

  11  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))

Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1

```

vendor/slowlyo/owl-admin/ 目录下 没有 config/admin.php 文件 当前 出现问题的版本 是 v3.9.7