### PR TITLE
EditorControl 添加 options 方法

### DIFF
--- a/src/Renderers/EditorControl.php
+++ b/src/Renderers/EditorControl.php
@@ -471,5 +471,14 @@ class EditorControl extends BaseRenderer
         return $this->set('width', $value);
     }
 
+    /**
+     * monaco 编辑器的其它配置，比如是否显示行号等，请参考这里 https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IEditorOptions.html
+     * 不过无法设置 readOnly，只读模式需要使用 disabled: true
+     */
+    public function options($value = '')
+    {
+        return $this->set('options', $value);
+    }
+
 
 }


### PR DESCRIPTION
https://baidu.github.io/amis/zh-CN/components/form/editor#%E5%B1%9E%E6%80%A7%E8%A1%A8

options	object		monaco 编辑器的其它配置，比如是否显示行号等，请参考[这里](https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IEditorOptions.html)，不过无法设置 readOnly，只读模式需要使用 disabled: true