### PR TITLE
fix:Picker弹窗大小参数改为modelSize

### DIFF
--- a/src/Renderers/PickerControl.php
+++ b/src/Renderers/PickerControl.php
@@ -541,9 +541,9 @@ class PickerControl extends BaseRenderer
     /**
      * 表单项大小 可选值: xs | sm | md | lg | full
      */
-    public function size($value = '')
+    public function modalSize($value = '')
     {
-        return $this->set('size', $value);
+        return $this->set('modalSize', $value);
     }
 
     /**


### PR DESCRIPTION
amis在6.12.0将Picker弹窗大小参数改为modalSize
[https://github.com/baidu/amis/pull/11664](url)