### PR TITLE
修复代码生成器获取连接筛选错误

### DIFF
--- a/src/Support/CodeGenerator/Generator.php
+++ b/src/Support/CodeGenerator/Generator.php
@@ -87,9 +87,9 @@ class Generator
     public function getDatabaseColumns($db = null)
     {
         // 获取所有支持的数据库连接
-        $databases = Arr::where(config('database.connections', []), function ($value) {
+        $databases = Arr::where(config('database.connections', []), function ($value, $connectName) {
             $supports = Admin::config('admin.database.generator') ?: [config("database.default")];
-            return in_array(strtolower(Arr::get($value, 'driver')), $supports);
+            return in_array($connectName, $supports);
         });
 
         $data = [];
@@ -301,10 +301,9 @@ class Generator
 
     public function getDatabasePrimaryKeys($db = null, $tb = null)
     {
-        $databases = Arr::where(config('database.connections', []), function ($value) {
+        $databases = Arr::where(config('database.connections', []), function ($value, $connectName) {
             $supports = Admin::config('admin.database.generator') ?: [config("database.default")];
-
-            return in_array(strtolower(Arr::get($value, 'driver')), $supports);
+            return in_array($connectName, $supports);
         });
 
         $data = [];


### PR DESCRIPTION
如果默认连接名称非数据库驱动名称会导致筛选错误，从而查不到数据