### PR TITLE
jsonSerialize方法返回类型声明

### DIFF
--- a/src/Renderers/BaseRenderer.php
+++ b/src/Renderers/BaseRenderer.php
@@ -39,7 +39,7 @@ class BaseRenderer implements \JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->filteredResults();
     }


### PR DESCRIPTION
jsonSerialize未定义返回类型，与接口声明不一致。