### PR TITLE
chore: P0 稳健维护 — 锁定 amis 6.13.0 与依赖约束

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/admin-views"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "amis"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "amis-ui"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "amis-core"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "amis-editor"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "amis-editor-core"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+    groups:
+      amis:
+        patterns:
+          - "amis"
+          - "amis-ui"
+          - "amis-core"
+          - "amis-editor"
+          - "amis-editor-core"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     </a>
 &nbsp;
       <a href="https://aisuda.bce.baidu.com/amis/zh-CN/docs/index">
-        <img src="https://img.shields.io/badge/Amis-3.0%2B-%23268af1" alt="">
+        <img src="https://img.shields.io/badge/Amis-6.13.x%20(locked)-%23268af1" alt="">
     </a>
 &nbsp;
       <a href="https://packagist.org/packages/slowlyo/owl-admin">
@@ -42,6 +42,8 @@
 基于 `Laravel` 、 `amis` 开发的后台框架, 快速且灵活~
 
 当前版本支持 `Laravel 11.x - 13.x`。
+
+amis 上游已基本停更，本框架前端锁定 amis 6.13.0，稳健维护期不以追新 amis 版本为目标。
 
 - 基于 amis 以 json 的方式在后端构建页面，减少前端开发工作量，提升开发效率。
 - 在 amis 150多个组件都不满足的情况下, 可自行开发前端。

--- a/admin-views/package.json
+++ b/admin-views/package.json
@@ -15,11 +15,11 @@
     "@wangeditor/editor": "^5.1.23",
     "@wangeditor/editor-for-react": "^1.0.6",
     "ahooks": "^3.8.4",
-    "amis": "^6.13.0",
+    "amis": "6.13.0",
     "amis-core": "6.13.0",
     "amis-editor": "6.13.0",
     "amis-editor-core": "6.13.0",
-    "amis-ui": "^6.13.0",
+    "amis-ui": "6.13.0",
     "antd": "^5.23.4",
     "axios": "^0.24.0",
     "clsx": "^2.1.1",
@@ -74,5 +74,22 @@
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix --cache"
     ]
+  },
+  "overrides": {
+    "amis": "6.13.0",
+    "amis-core": "6.13.0",
+    "amis-ui": "6.13.0",
+    "amis-editor": "6.13.0",
+    "amis-editor-core": "6.13.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "npm:rolldown-vite@7.3.0",
+      "amis": "6.13.0",
+      "amis-core": "6.13.0",
+      "amis-ui": "6.13.0",
+      "amis-editor": "6.13.0",
+      "amis-editor-core": "6.13.0"
+    }
   }
 }

--- a/admin-views/pnpm-lock.yaml
+++ b/admin-views/pnpm-lock.yaml
@@ -6,6 +6,11 @@ settings:
 
 overrides:
   vite: npm:rolldown-vite@7.3.0
+  amis: 6.13.0
+  amis-core: 6.13.0
+  amis-ui: 6.13.0
+  amis-editor: 6.13.0
+  amis-editor-core: 6.13.0
 
 importers:
 
@@ -33,7 +38,7 @@ importers:
         specifier: ^3.8.4
         version: 3.8.4(react@17.0.2)
       amis:
-        specifier: ^6.13.0
+        specifier: 6.13.0
         version: 6.13.0(@types/react@17.0.83)(amis-core@6.13.0(@types/react@17.0.83)(amis-formula@6.9.0)(react-dom@17.0.2(react@17.0.2))(react-is@18.3.1)(react@17.0.2))(amis-ui@6.13.0(@types/react@17.0.83)(amis-core@6.13.0(@types/react@17.0.83)(amis-formula@6.9.0)(react-dom@17.0.2(react@17.0.2))(react-is@18.3.1)(react@17.0.2))(amis-formula@6.9.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(office-viewer@0.3.13(echarts@5.5.1))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       amis-core:
         specifier: 6.13.0
@@ -45,7 +50,7 @@ importers:
         specifier: 6.13.0
         version: 6.13.0(e8dfbe55e1901e28f21ca425a909afd9)
       amis-ui:
-        specifier: ^6.13.0
+        specifier: 6.13.0
         version: 6.13.0(@types/react@17.0.83)(amis-core@6.13.0(@types/react@17.0.83)(amis-formula@6.9.0)(react-dom@17.0.2(react@17.0.2))(react-is@18.3.1)(react@17.0.2))(amis-formula@6.9.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       antd:
         specifier: ^5.23.4

--- a/admin-views/pnpm-workspace.yaml
+++ b/admin-views/pnpm-workspace.yaml
@@ -1,5 +1,10 @@
 overrides:
   vite: npm:rolldown-vite@7.3.0
+  amis: 6.13.0
+  amis-core: 6.13.0
+  amis-ui: 6.13.0
+  amis-editor: 6.13.0
+  amis-editor-core: 6.13.0
 
 blockExoticSubdeps: false
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.2",
         "illuminate/support": "^11.0|^12.0|^13.0",
-        "slowlyo/laravel-support": "*",
+        "slowlyo/laravel-support": "^0.0.7",
         "ext-zip": "*",
         "ext-gd": "*"
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P0 稳健维护：钉死前端 amis 版本、收紧 Composer 约束、补上 Dependabot，避免 caret / `*` 漂移。

### 1. 锁定 amis 6.13.0（禁止 caret 漂移）

`admin-views` 使用 pnpm（已有 `pnpm-lock.yaml` / `pnpm-workspace.yaml`，vite 为 `rolldown-vite@7.3.0`）。

- `amis`、`amis-ui`：`^6.13.0` → 精确 `6.13.0`
- `amis-core`、`amis-editor`、`amis-editor-core`：保持 `6.13.0`
- `package.json` 增加 npm `overrides` 与 `pnpm.overrides`，将上述 5 个包钉在 `6.13.0`（未钉 `amis-formula` / `amis-theme-editor-helper` / `amis-postcss`，它们本身就不是 6.13.0）
- `pnpm-workspace.yaml` 同步写入同一组 overrides（本仓库现有 vite override 也在这里）
- `pnpm.overrides` 保留已有的 `vite: npm:rolldown-vite@7.3.0`，避免 package.json overrides 覆盖 workspace 时丢掉 vite 钉版本
- lockfile 只改了 specifier 与 overrides 段；`pnpm install --frozen-lockfile` 已通过，解析结果仍为 amis 6.13.0

未把 `amis*` 字面 glob 钉到 6.13.0：传递依赖里 `amis-formula@6.9.0`、`amis-theme-editor-helper@2.0.26`、`amis-postcss@1.0.0` 并没有 6.13.0。

### 2. README

- Badge：`Amis-3.0+` → `Amis-6.13.x (locked)`
- 项目介绍补充：amis 上游已基本停更，前端锁定 6.13.0，稳健维护期不以追新为目标
- 仓库无 `docs/` 目录，未新增 `docs/maintenance.md`

### 3. Composer

- `slowlyo/laravel-support`: `*` → `^0.0.7`

### 4. Dependabot

新增 `.github/dependabot.yml`：

- 每周更新：`composer` `/`、`npm` `/admin-views`
- `open-pull-requests-limit: 5`
- 忽略 `amis` / `amis-ui` / `amis-core` / `amis-editor` / `amis-editor-core` 的 major 与 minor，避免跳出 6.13.x；patch（若有 6.13.1）仍可开 PR 并归入 `amis` group

## Test plan

- [x] `admin-views` 下 `pnpm install --frozen-lockfile` 成功，直接依赖为 `amis` / `amis-ui` / `amis-core` / `amis-editor` / `amis-editor-core` **6.13.0**
- [x] vite 仍解析为 `rolldown-vite@7.3.0`
- [ ] CI / 本地完整前端 build（本次未跑 `pnpm build`）
- [ ] Composer 在 Laravel 11–13 应用中解析 `slowlyo/laravel-support:^0.0.7`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53554277-8496-4487-bb50-b3de3a402805?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53554277-8496-4487-bb50-b3de3a402805&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

